### PR TITLE
Use prefix for environment variable

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -16,7 +16,7 @@ return [
      */
     'database' => [
         'enabled'    => false,
-        'connection' => env('DB_CONNECTION', 'mysql'),
+        'connection' => env('PHP_TELEGRAM_BOT_DB_CONNECTION', 'mysql'),
     ],
 
     'commands' => [


### PR DESCRIPTION
Allows you to use a separate database