### PR TITLE
Add all missing migrations up until 0.70.0 of core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
+sudo: false
 
 php:
-    - 7.2
-    - 7.3
-    - 7.4
-
-sudo: false
+  - 7.2
+  - 7.3
+  - 7.4
 
 before_install:
   - composer self-update
@@ -17,7 +16,6 @@ script:
   - ./vendor/bin/phpcs --standard=phpcs.xml -spn --encoding=utf-8 src/ --report-width=150
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
-
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml
@@ -25,7 +23,6 @@ after_script:
 matrix:
   fast_finish: true
 
-
 notifications:
-    on_success: never
-    on_failure: always
+  on_success: never
+  on_failure: always

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,0 +1,82 @@
+## Example ##
+
+
+1- After adding the package setting everything up, create a controller, for example `TelegramController.php` in you `app/Http/Controllers` directory and put this in it:
+
+```
+<?php
+namespace App\Http\Controllers;
+
+use PhpTelegramBot\Laravel\PhpTelegramBotContract;
+
+class TelegramController extends Controller {
+    public function set(PhpTelegramBotContract $telegram_bot) {
+        return $telegram_bot->setWebhook(url(config('phptelegrambot.bot.api_key') . '/hook'));
+    }
+
+    public function hook(PhpTelegramBotContract $telegram_bot) {
+        $telegram_bot->handle();
+    }
+}
+```
+
+2- Now you need to write routes for these actions. so open your `web.php` and write:
+```
+$router->group(['prefix' => '[YOUR BOT API KEY]', function() use ($router) {
+    $router->get('set', 'TelegramController@set');
+    $router->post('hook', 'TelegramController@hook');
+});
+```
+replace [YOUR BOT API KEY] with the API key that BotFather has given you. This is to make secure the `hook` url to ensure the incoming requests are from no one but Telegram.
+
+3- Go to `https://yoursite.com/[YOUR BOT API KEY]/set`
+You should see the success message.
+
+4- Create a directory for your commands. It can be anywhere, for example `app/Telegram/Commands/[CommandNameCommand].php` would be nice.
+
+This is an example `StartCommand.php`:
+```
+<?php
+namespace Longman\TelegramBot\Commands\SystemCommands;
+
+use Longman\TelegramBot\Commands\SystemCommand;
+use Longman\TelegramBot\Request;
+
+class StartCommand extends SystemCommand {
+	protected $name = 'start';
+	protected $usage = '/start';
+
+	public function execute()
+	{
+		$message = $this->getMessage();
+
+        	$chat_id = $message->getChat()->getId();
+        	$text    = 'Hi! Welcome to my bot!';
+
+        	$data = [
+            		'chat_id' => $chat_id,
+            		'text'    => $text,
+        	];
+
+        	return Request::sendMessage($data);
+	}
+}
+```
+5- The last thing you need to do is to add your custom commands directory to the bot's config. so open `config/phptelegrambot.php` and add the commands directory to the array:
+
+```
+...
+'commands' => [
+        'before'  => true,
+        'paths'   => [
+            base_path('/app/Telegram/Commands')
+        ],
+        'configs' => [
+            // Custom commands configs
+        ],
+],
+...
+```
+
+
+That's it.

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -22,12 +22,12 @@ class TelegramController extends Controller {
 
 2- Now you need to write routes for these actions. so open your `web.php` and write:
 ```
-$router->group(['prefix' => '[YOUR BOT API KEY]', function() use ($router) {
+$router->group(['prefix' => config('phptelegrambot.bot.api_key')], function() use ($router) {
     $router->get('set', 'TelegramController@set');
     $router->post('hook', 'TelegramController@hook');
 });
 ```
-replace [YOUR BOT API KEY] with the API key that BotFather has given you. This is to make secure the `hook` url to ensure the incoming requests are from no one but Telegram.
+We prefix all routes with the long API key that BotFather has given us to make the `hook` url secure and to ensure the incoming requests are from no one but Telegram.
 
 3- Go to `https://yoursite.com/[YOUR BOT API KEY]/set`
 You should see the success message.

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,7 +1,7 @@
 ## Example ##
 
 
-1- After adding the package setting everything up, create a controller, for example `TelegramController.php` in you `app/Http/Controllers` directory and put this in it:
+1- After adding the package and setting everything up, create a controller, for example `TelegramController.php` in your `app/Http/Controllers` directory and put this in it:
 
 ```
 <?php

--- a/src/Laravel/Commands/WebhookCommand.php
+++ b/src/Laravel/Commands/WebhookCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PhpTelegramBot/Laravel package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace PhpTelegramBot\Laravel\Commands;
@@ -25,10 +34,10 @@ class WebhookCommand extends Command
         $this->telegramBot = $telegramBot;
     }
 
-    public function handle()
+    public function handle(): void
     {
         $webhook = $this->argument('webhook');
-        $delete = $this->option('delete');
+        $delete  = $this->option('delete');
 
         if (! ($webhook || $delete)) {
             $this->error('Not enough arguments!');
@@ -39,7 +48,7 @@ class WebhookCommand extends Command
         if ($delete) {
             try {
                 $this->telegramBot->deleteWebhook();
-                $this->info('Webhook deleted succesfully!');
+                $this->info('Webhook deleted successfully!');
             } catch (TelegramException $e) {
                 $this->error("Couldn't delete webhook");
                 $this->error($e->getMessage());
@@ -47,11 +56,10 @@ class WebhookCommand extends Command
             }
         }
 
-
         if ($webhook) {
             try {
                 $this->telegramBot->setWebhook($webhook);
-                $this->info('Webhook set succesfully!');
+                $this->info('Webhook set successfully!');
             } catch (TelegramException $e) {
                 $this->error("Couldn't set webhook");
                 $this->error($e->getMessage());

--- a/src/Laravel/Migration.php
+++ b/src/Laravel/Migration.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the PhpTelegramBot/Laravel package.
  *
@@ -11,13 +9,13 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace PhpTelegramBot\Laravel;
 
 class Migration extends \Illuminate\Database\Migrations\Migration
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $prefix = '';
 
     public function __construct()

--- a/src/Laravel/Migration.php
+++ b/src/Laravel/Migration.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace PhpTelegramBot\Laravel;
 
+use Illuminate\Support\Facades\DB;
+
 class Migration extends \Illuminate\Database\Migrations\Migration
 {
     /** @var string */
@@ -21,5 +23,35 @@ class Migration extends \Illuminate\Database\Migrations\Migration
     public function __construct()
     {
         $this->prefix = (string) config('phptelegrambot.database.prefix', '');
+    }
+
+    /**
+     * Change column type for passed table field(s).
+     *
+     * @param array  $table_columns
+     * @param string $new_type
+     */
+    public function changeColumnTypes(array $table_columns, string $new_type): void
+    {
+        $database = DB::connection()->getDatabaseName();
+        $prefix   = DB::connection()->getTablePrefix() . $this->prefix;
+
+        foreach ($table_columns as $table => $columns) {
+            foreach ($columns as $column) {
+                // Preserve column comment and nullable state.
+                $props = DB::selectOne('
+                    SELECT `COLUMN_COMMENT`, `IS_NULLABLE`
+                    FROM `information_schema`.`COLUMNS`
+                    WHERE `TABLE_SCHEMA` = ?
+                      AND `TABLE_NAME` = ?
+                      AND `COLUMN_NAME` = ?
+                    LIMIT 1
+                ', [$database, $prefix . $table, $column]);
+
+                $comment  = $props->COLUMN_COMMENT;
+                $nullable = $props->IS_NULLABLE === 'YES' ? 'NULL' : 'NOT NULL';
+                DB::statement("ALTER TABLE `{$prefix}{$table}` CHANGE `{$column}` `{$column}` {$new_type} {$nullable} COMMENT '{$comment}'");
+            }
+        }
     }
 }

--- a/src/Laravel/Migration.php
+++ b/src/Laravel/Migration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the PhpTelegramBot/Laravel package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTelegramBot\Laravel;
+
+class Migration extends \Illuminate\Database\Migrations\Migration
+{
+    /**
+     * @var string
+     */
+    protected $prefix = '';
+
+    public function __construct()
+    {
+        $this->prefix = (string) config('phptelegrambot.database.prefix', '');
+    }
+}

--- a/src/Laravel/PhpTelegramBot.php
+++ b/src/Laravel/PhpTelegramBot.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the PhpTelegramBot/Laravel package.
  *
@@ -10,6 +8,9 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace PhpTelegramBot\Laravel;
 
 use Longman\TelegramBot\Telegram;

--- a/src/Laravel/PhpTelegramBotContract.php
+++ b/src/Laravel/PhpTelegramBotContract.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the PhpTelegramBot/Laravel package.
  *
@@ -10,6 +8,9 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace PhpTelegramBot\Laravel;
 
 /**

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the PhpTelegramBot/Laravel package.
  *
@@ -10,6 +8,9 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace PhpTelegramBot\Laravel;
 
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
@@ -29,7 +30,7 @@ class ServiceProvider extends LaravelServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         // Publish config files
         $this->publishes([
@@ -52,7 +53,7 @@ class ServiceProvider extends LaravelServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->bind(PhpTelegramBotContract::class, static function ($app) {
             $config = $app['config']->get('phptelegrambot');
@@ -108,7 +109,7 @@ class ServiceProvider extends LaravelServiceProvider
      *
      * @return array
      */
-    public function provides()
+    public function provides(): array
     {
         return [PhpTelegramBotContract::class];
     }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -17,7 +17,7 @@ return [
     'database' => [
         'enabled'    => false,
         'connection' => env('DB_CONNECTION', 'mysql'),
-        'prefix'     => '',
+        'prefix'     => env('PHP_TELEGRAM_BOT_TABLE_PREFIX', ''),
     ],
 
     'commands' => [
@@ -42,6 +42,6 @@ return [
         'interval' => 1,
     ],
 
-    'upload_path'   => '',
-    'download_path' => '',
+    'upload_path'   => env('PHP_TELEGRAM_BOT_UPLOAD_PATH', ''),
+    'download_path' => env('PHP_TELEGRAM_BOT_DOWNLOAD_PATH', ''),
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -17,6 +17,7 @@ return [
     'database' => [
         'enabled'    => false,
         'connection' => env('DB_CONNECTION', 'mysql'),
+        'prefix'     => '',
     ],
 
     'commands' => [

--- a/src/database/migrations/2018_04_18_193554_create_botan_shortener_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_botan_shortener_table.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateBotanShortenerTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('botan_shortener', static function (Blueprint $table) {
             $table->bigInteger('id', true)->unsigned()->comment('Unique identifier for this entry');
             $table->bigInteger('user_id')->nullable()->index('user_id')->comment('Unique user identifier');
-            $table->text('url', 65535)->comment('Original URL');
+            $table->text('url')->comment('Original URL');
             $table->char('short_url')->default('')->comment('Shortened URL');
             $table->dateTime('created_at')->nullable()->comment('Entry date creation');
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('botan_shortener');
+        Schema::dropIfExists('botan_shortener');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_callback_query_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_callback_query_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateCallbackQueryTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('callback_query', static function (Blueprint $table) {
             $table->bigInteger('id')->unsigned()->primary()->comment('Unique identifier for this query');
@@ -21,8 +22,8 @@ class CreateCallbackQueryTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('callback_query');
+        Schema::dropIfExists('callback_query');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_chat_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_chat_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateChatTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('chat', static function (Blueprint $table) {
             $table->bigInteger('id')->primary()->comment('Unique user or chat identifier');
@@ -20,8 +21,8 @@ class CreateChatTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('chat');
+        Schema::dropIfExists('chat');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_chosen_inline_result_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_chosen_inline_result_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateChosenInlineResultTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('chosen_inline_result', static function (Blueprint $table) {
             $table->bigInteger('id', true)->unsigned()->comment('Unique identifier for this entry');
@@ -15,13 +16,13 @@ class CreateChosenInlineResultTable extends Migration
             $table->bigInteger('user_id')->nullable()->index('user_id')->comment('Unique user identifier');
             $table->char('location')->nullable()->comment('Location object, user\'s location');
             $table->char('inline_message_id')->nullable()->comment('Identifier of the sent inline message');
-            $table->text('query', 65535)->comment('The query that was used to obtain the result');
+            $table->text('query')->comment('The query that was used to obtain the result');
             $table->dateTime('created_at')->nullable()->comment('Entry date creation');
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('chosen_inline_result');
+        Schema::dropIfExists('chosen_inline_result');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_conversation_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_conversation_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateConversationTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('conversation', static function (Blueprint $table) {
             $table->bigInteger('id', true)->unsigned()->comment('Unique identifier for this entry');
@@ -15,13 +16,13 @@ class CreateConversationTable extends Migration
             $table->bigInteger('chat_id')->nullable()->index('chat_id')->comment('Unique user or chat identifier');
             $table->enum('status', ['active', 'cancelled', 'stopped'])->default('active')->index('status')->comment('Conversation state');
             $table->string('command', 160)->nullable()->default('')->comment('Default command to execute');
-            $table->text('notes', 65535)->nullable()->comment('Data stored from command');
+            $table->text('notes')->nullable()->comment('Data stored from command');
             $table->timestamps();
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('conversation');
+        Schema::dropIfExists('conversation');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_edited_message_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_edited_message_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateEditedMessageTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('edited_message', static function (Blueprint $table) {
             $table->bigInteger('id', true)->unsigned()->comment('Unique identifier for this entry');
@@ -15,18 +16,15 @@ class CreateEditedMessageTable extends Migration
             $table->bigInteger('message_id')->unsigned()->nullable()->index('message_id')->comment('Unique message identifier');
             $table->bigInteger('user_id')->nullable()->index('user_id')->comment('Unique user identifier');
             $table->dateTime('edit_date')->nullable()->comment('Date the message was edited in timestamp format');
-            $table->text('text', 65535)->nullable()->comment('For text messages, the actual UTF-8 text of the message max message length 4096 char utf8');
-            $table->text(
-                'entities',
-                65535
-            )->nullable()->comment('For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text');
-            $table->text('caption', 65535)->nullable()->comment('For message with caption, the actual UTF-8 text of the caption');
+            $table->text('text')->nullable()->comment('For text messages, the actual UTF-8 text of the message max message length 4096 char utf8');
+            $table->text('entities')->nullable()->comment('For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text');
+            $table->text('caption')->nullable()->comment('For message with caption, the actual UTF-8 text of the caption');
             $table->index(['chat_id', 'message_id'], 'chat_id_2');
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('edited_message');
+        Schema::dropIfExists('edited_message');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_inline_query_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_inline_query_table.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateInlineQueryTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('inline_query', static function (Blueprint $table) {
             $table->bigInteger('id')->unsigned()->primary()->comment('Unique identifier for this query');
             $table->bigInteger('user_id')->nullable()->index('user_id')->comment('Unique user identifier');
             $table->char('location')->nullable()->comment('Location of the user');
-            $table->text('query', 65535)->comment('Text of the query');
+            $table->text('query')->comment('Text of the query');
             $table->char('offset')->nullable()->comment('Offset of the result');
             $table->dateTime('created_at')->nullable()->comment('Entry date creation');
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('inline_query');
+        Schema::dropIfExists('inline_query');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_message_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_message_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateMessageTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('message', static function (Blueprint $table) {
             $table->bigInteger('chat_id')->comment('Unique chat identifier');
@@ -20,45 +21,39 @@ class CreateMessageTable extends Migration
             $table->dateTime('forward_date')->nullable()->comment('date the original message was sent in timestamp format');
             $table->bigInteger('reply_to_chat')->nullable()->index('reply_to_chat')->comment('Unique chat identifier');
             $table->bigInteger('reply_to_message')->unsigned()->nullable()->index('reply_to_message')->comment('Message that this message is reply to');
-            $table->text('media_group_id', 65535)->nullable()->comment('The unique identifier of a media message group this message belongs to');
-            $table->text('text', 65535)->nullable()->comment('For text messages, the actual UTF-8 text of the message max message length 4096 char utf8mb4');
-            $table->text(
-                'entities',
-                65535
-            )->nullable()->comment('For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text');
-            $table->text('audio', 65535)->nullable()->comment('Audio object. Message is an audio file, information about the file');
-            $table->text('document', 65535)->nullable()->comment('Document object. Message is a general file, information about the file');
-            $table->text('photo', 65535)->nullable()->comment('Array of PhotoSize objects. Message is a photo, available sizes of the photo');
-            $table->text('sticker', 65535)->nullable()->comment('Sticker object. Message is a sticker, information about the sticker');
-            $table->text('video', 65535)->nullable()->comment('Video object. Message is a video, information about the video');
-            $table->text('voice', 65535)->nullable()->comment('Voice Object. Message is a Voice, information about the Voice');
-            $table->text('video_note', 65535)->nullable()->comment('VoiceNote Object. Message is a Video Note, information about the Video Note');
-            $table->text('contact', 65535)->nullable()->comment('Contact object. Message is a shared contact, information about the contact');
-            $table->text('location', 65535)->nullable()->comment('Location object. Message is a shared location, information about the location');
-            $table->text('venue', 65535)->nullable()->comment('Venue object. Message is a Venue, information about the Venue');
-            $table->text('caption', 65535)->nullable()->comment('For message with caption, the actual UTF-8 text of the caption');
-            $table->text(
-                'new_chat_members',
-                65535
-            )->nullable()->comment('List of unique user identifiers, new member(s) were added to the group, information about them (one of these members may be the bot itself)');
+            $table->text('media_group_id')->nullable()->comment('The unique identifier of a media message group this message belongs to');
+            $table->text('text')->nullable()->comment('For text messages, the actual UTF-8 text of the message max message length 4096 char utf8mb4');
+            $table->text('entities')->nullable()->comment('For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text');
+            $table->text('audio')->nullable()->comment('Audio object. Message is an audio file, information about the file');
+            $table->text('document')->nullable()->comment('Document object. Message is a general file, information about the file');
+            $table->text('photo')->nullable()->comment('Array of PhotoSize objects. Message is a photo, available sizes of the photo');
+            $table->text('sticker')->nullable()->comment('Sticker object. Message is a sticker, information about the sticker');
+            $table->text('video')->nullable()->comment('Video object. Message is a video, information about the video');
+            $table->text('voice')->nullable()->comment('Voice Object. Message is a Voice, information about the Voice');
+            $table->text('video_note')->nullable()->comment('VoiceNote Object. Message is a Video Note, information about the Video Note');
+            $table->text('contact')->nullable()->comment('Contact object. Message is a shared contact, information about the contact');
+            $table->text('location')->nullable()->comment('Location object. Message is a shared location, information about the location');
+            $table->text('venue')->nullable()->comment('Venue object. Message is a Venue, information about the Venue');
+            $table->text('caption')->nullable()->comment('For message with caption, the actual UTF-8 text of the caption');
+            $table->text('new_chat_members')->nullable()->comment('List of unique user identifiers, new member(s) were added to the group, information about them (one of these members may be the bot itself)');
             $table->bigInteger('left_chat_member')->nullable()->index('left_chat_member')->comment('Unique user identifier, a member was removed from the group, information about them (this member may be the bot itself)');
             $table->char('new_chat_title')->nullable()->comment('A chat title was changed to this value');
-            $table->text('new_chat_photo', 65535)->nullable()->comment('Array of PhotoSize objects. A chat photo was change to this value');
+            $table->text('new_chat_photo')->nullable()->comment('Array of PhotoSize objects. A chat photo was change to this value');
             $table->boolean('delete_chat_photo')->nullable()->default(0)->comment('Informs that the chat photo was deleted');
             $table->boolean('group_chat_created')->nullable()->default(0)->comment('Informs that the group has been created');
             $table->boolean('supergroup_chat_created')->nullable()->default(0)->comment('Informs that the supergroup has been created');
             $table->boolean('channel_chat_created')->nullable()->default(0)->comment('Informs that the channel chat has been created');
             $table->bigInteger('migrate_to_chat_id')->nullable()->index('migrate_to_chat_id')->comment('Migrate to chat identifier. The group has been migrated to a supergroup with the specified identifier');
             $table->bigInteger('migrate_from_chat_id')->nullable()->index('migrate_from_chat_id')->comment('Migrate from chat identifier. The supergroup has been migrated from a group with the specified identifier');
-            $table->text('pinned_message', 65535)->nullable()->comment('Message object. Specified message was pinned');
-            $table->text('connected_website', 65535)->nullable()->comment('The domain name of the website on which the user has logged in.');
+            $table->text('pinned_message')->nullable()->comment('Message object. Specified message was pinned');
+            $table->text('connected_website')->nullable()->comment('The domain name of the website on which the user has logged in.');
             $table->primary(['chat_id', 'id']);
             $table->index(['reply_to_chat', 'reply_to_message'], 'reply_to_chat_2');
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('message');
+        Schema::dropIfExists('message');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_request_limiter_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_request_limiter_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateRequestLimiterTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('request_limiter', static function (Blueprint $table) {
             $table->bigInteger('id', true)->unsigned()->comment('Unique identifier for this entry');
@@ -18,8 +19,8 @@ class CreateRequestLimiterTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('request_limiter');
+        Schema::dropIfExists('request_limiter');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_telegram_update_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_telegram_update_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateTelegramUpdateTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('telegram_update', static function (Blueprint $table) {
             $table->bigInteger('id')->unsigned()->primary()->comment('Update\'s unique identifier');
@@ -21,8 +22,8 @@ class CreateTelegramUpdateTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('telegram_update');
+        Schema::dropIfExists('telegram_update');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_user_chat_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_user_chat_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateUserChatTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('user_chat', static function (Blueprint $table) {
             $table->bigInteger('user_id')->comment('Unique user identifier');
@@ -16,8 +17,8 @@ class CreateUserChatTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('user_chat');
+        Schema::dropIfExists('user_chat');
     }
 }

--- a/src/database/migrations/2018_04_18_193554_create_user_table.php
+++ b/src/database/migrations/2018_04_18_193554_create_user_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateUserTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('user', static function (Blueprint $table) {
             $table->bigInteger('id')->primary()->comment('Unique user identifier');
@@ -20,8 +21,8 @@ class CreateUserTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::drop('user');
+        Schema::dropIfExists('user');
     }
 }

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_botan_shortener_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_botan_shortener_table.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToBotanShortenerTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('botan_shortener', static function (Blueprint $table) {
             $table->foreign('user_id', 'botan_shortener_ibfk_1')->references('id')->on('user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('botan_shortener', static function (Blueprint $table) {
             $table->dropForeign('botan_shortener_ibfk_1');

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_callback_query_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_callback_query_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToCallbackQueryTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('callback_query', static function (Blueprint $table) {
             $table->foreign('user_id', 'callback_query_ibfk_1')->references('id')->on('user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
@@ -15,7 +16,7 @@ class AddForeignKeysToCallbackQueryTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('callback_query', static function (Blueprint $table) {
             $table->dropForeign('callback_query_ibfk_1');

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_chosen_inline_result_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_chosen_inline_result_table.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToChosenInlineResultTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('chosen_inline_result', static function (Blueprint $table) {
             $table->foreign('user_id', 'chosen_inline_result_ibfk_1')->references('id')->on('user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('chosen_inline_result', static function (Blueprint $table) {
             $table->dropForeign('chosen_inline_result_ibfk_1');

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_conversation_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_conversation_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToConversationTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('conversation', static function (Blueprint $table) {
             $table->foreign('user_id', 'conversation_ibfk_1')->references('id')->on('user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
@@ -15,7 +16,7 @@ class AddForeignKeysToConversationTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('conversation', static function (Blueprint $table) {
             $table->dropForeign('conversation_ibfk_1');

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_edited_message_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_edited_message_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToEditedMessageTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('edited_message', static function (Blueprint $table) {
             $table->foreign('chat_id', 'edited_message_ibfk_1')->references('id')->on('chat')->onUpdate('RESTRICT')->onDelete('RESTRICT');
@@ -16,7 +17,7 @@ class AddForeignKeysToEditedMessageTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('edited_message', static function (Blueprint $table) {
             $table->dropForeign('edited_message_ibfk_1');

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_inline_query_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_inline_query_table.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToInlineQueryTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('inline_query', static function (Blueprint $table) {
             $table->foreign('user_id', 'inline_query_ibfk_1')->references('id')->on('user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('inline_query', static function (Blueprint $table) {
             $table->dropForeign('inline_query_ibfk_1');

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_message_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_message_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToMessageTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('message', static function (Blueprint $table) {
             $table->foreign('user_id', 'message_ibfk_1')->references('id')->on('user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
@@ -20,7 +21,7 @@ class AddForeignKeysToMessageTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('message', static function (Blueprint $table) {
             $table->dropForeign('message_ibfk_1');

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_telegram_update_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_telegram_update_table.php
@@ -4,24 +4,22 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToTelegramUpdateTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('telegram_update', static function (Blueprint $table) {
             $table->foreign('chat_id', 'telegram_update_ibfk_1')->references('chat_id')->on('message')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             $table->foreign('inline_query_id', 'telegram_update_ibfk_2')->references('id')->on('inline_query')->onUpdate('RESTRICT')->onDelete('RESTRICT');
-            $table->foreign(
-                'chosen_inline_result_id',
-                'telegram_update_ibfk_3'
-            )->references('id')->on('chosen_inline_result')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            $table->foreign('chosen_inline_result_id', 'telegram_update_ibfk_3')->references('id')->on('chosen_inline_result')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             $table->foreign('callback_query_id', 'telegram_update_ibfk_4')->references('id')->on('callback_query')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             $table->foreign('edited_message_id', 'telegram_update_ibfk_5')->references('id')->on('edited_message')->onUpdate('RESTRICT')->onDelete('RESTRICT');
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('telegram_update', static function (Blueprint $table) {
             $table->dropForeign('telegram_update_ibfk_1');

--- a/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_user_chat_table.php
+++ b/src/database/migrations/2018_04_18_193555_add_foreign_keys_to_user_chat_table.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddForeignKeysToUserChatTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('user_chat', static function (Blueprint $table) {
             $table->foreign('user_id', 'user_chat_ibfk_1')->references('id')->on('user')->onUpdate('CASCADE')->onDelete('CASCADE');
@@ -15,7 +16,7 @@ class AddForeignKeysToUserChatTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::table('user_chat', static function (Blueprint $table) {
             $table->dropForeign('user_chat_ibfk_1');

--- a/src/database/migrations/2020_05_18_000000_add_prefix_to_tables.php
+++ b/src/database/migrations/2020_05_18_000000_add_prefix_to_tables.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
+
+class AddPrefixToTables extends Migration
+{
+    /** @var string[] All PHP Telegram Bot database tables. */
+    private $tables = [
+        'botan_shortener',
+        'callback_query',
+        'chat',
+        'chosen_inline_result',
+        'conversation',
+        'edited_message',
+        'inline_query',
+        'message',
+        'user',
+        'request_limiter',
+        'telegram_update',
+        'user_chat',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            try {
+                if (Schema::hasTable($this->prefix . $table)) {
+                    Log::warning("Prefixed table '{$this->prefix}{$table}' already exists. Verify your migration status.");
+                    continue; // Migration may be partly done already...
+                }
+
+                Schema::rename($table, $this->prefix . $table);
+            } catch (Throwable $e) {
+                Log::error($e->getMessage());
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            try {
+                if (Schema::hasTable($table)) {
+                    Log::warning("Un-prefixed table '{$table}' already exists. Verify your migration status.");
+                    continue; // Migration may be partly done already...
+                }
+
+                Schema::rename($this->prefix . $table, $table);
+            } catch (Throwable $e) {
+                Log::error($e->getMessage());
+            }
+        }
+    }
+}

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use PhpTelegramBot\Laravel\Migration;
 
@@ -15,7 +16,7 @@ class UpdateSchema0530To0540 extends Migration
                 $table->text('game')->nullable()->comment('Message is a game, information about the game.')->after('document');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }
@@ -27,7 +28,7 @@ class UpdateSchema0530To0540 extends Migration
                 $table->dropColumn('game');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
 
 class UpdateSchema0530To0540 extends Migration
 {
     public function up(): void
     {
         try {
-            Schema::table('message', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->text('game')->nullable()->comment('Message is a game, information about the game.')->after('document');
             });
         } catch (Exception $e) {
@@ -22,7 +22,7 @@ class UpdateSchema0530To0540 extends Migration
     public function down(): void
     {
         try {
-            Schema::table('message', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->dropColumn('game');
             });
         } catch (Exception $e) {

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSchema0530To0540 extends Migration
+{
+    public function up(): void
+    {
+        try {
+            Schema::table('message', static function (Blueprint $table) {
+                $table->text('game')->nullable()->comment('Message is a game, information about the game.')->after('document');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+
+    public function down(): void
+    {
+        try {
+            Schema::table('message', static function (Blueprint $table) {
+                $table->dropColumn('game');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+}

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
@@ -15,6 +15,7 @@ class UpdateSchema0530To0540 extends Migration
                 $table->text('game')->nullable()->comment('Message is a game, information about the game.')->after('document');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }
@@ -26,6 +27,7 @@ class UpdateSchema0530To0540 extends Migration
                 $table->dropColumn('game');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_53_0_to_0_54_0.php
@@ -14,8 +14,8 @@ class UpdateSchema0530To0540 extends Migration
             Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->text('game')->nullable()->comment('Message is a game, information about the game.')->after('document');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 
@@ -25,8 +25,8 @@ class UpdateSchema0530To0540 extends Migration
             Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->dropColumn('game');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
@@ -16,6 +16,7 @@ class UpdateSchema0541To0550 extends Migration
                 $table->text('passport_data')->nullable()->comment('Telegram Passport data')->after('connected_website');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }
@@ -28,6 +29,7 @@ class UpdateSchema0541To0550 extends Migration
                 $table->dropColumn('animation');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
@@ -15,8 +15,8 @@ class UpdateSchema0541To0550 extends Migration
                 $table->text('animation')->nullable()->comment('Message is an animation, information about the animation')->after('document');
                 $table->text('passport_data')->nullable()->comment('Telegram Passport data')->after('connected_website');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 
@@ -27,8 +27,8 @@ class UpdateSchema0541To0550 extends Migration
                 $table->dropColumn('passport_data');
                 $table->dropColumn('animation');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
 
 class UpdateSchema0541To0550 extends Migration
 {
     public function up(): void
     {
         try {
-            Schema::table('message', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->text('animation')->nullable()->comment('Message is an animation, information about the animation')->after('document');
                 $table->text('passport_data')->nullable()->comment('Telegram Passport data')->after('connected_website');
             });
@@ -23,7 +23,7 @@ class UpdateSchema0541To0550 extends Migration
     public function down(): void
     {
         try {
-            Schema::table('message', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->dropColumn('passport_data');
                 $table->dropColumn('animation');
             });

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSchema0541To0550 extends Migration
+{
+    public function up(): void
+    {
+        try {
+            Schema::table('message', static function (Blueprint $table) {
+                $table->text('animation')->nullable()->comment('Message is an animation, information about the animation')->after('document');
+                $table->text('passport_data')->nullable()->comment('Telegram Passport data')->after('connected_website');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+
+    public function down(): void
+    {
+        try {
+            Schema::table('message', static function (Blueprint $table) {
+                $table->dropColumn('passport_data');
+                $table->dropColumn('animation');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+}

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_54_1_to_0_55_0.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use PhpTelegramBot\Laravel\Migration;
 
@@ -16,7 +17,7 @@ class UpdateSchema0541To0550 extends Migration
                 $table->text('passport_data')->nullable()->comment('Telegram Passport data')->after('connected_website');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }
@@ -29,7 +30,7 @@ class UpdateSchema0541To0550 extends Migration
                 $table->dropColumn('animation');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
 
 class UpdateSchema0560To0570 extends Migration
 {
     public function up(): void
     {
         try {
-            Schema::create('shipping_query', static function (Blueprint $table) {
+            Schema::create($this->prefix . 'shipping_query', function (Blueprint $table) {
                 $table->bigInteger('id')->unsigned()->primary()->comment('Unique query identifier');
                 $table->bigInteger('user_id')->index('user_id')->comment('User who sent the query');
                 $table->char('invoice_payload', 255)->default('')->comment('Bot specified invoice payload');
                 $table->char('shipping_address', 255)->default('')->comment('User specified shipping address');
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
-                $table->foreign('user_id', 'shipping_query_ibfk_1')->references('id')->on('user')->onUpdate('CASCADE')->onDelete('CASCADE');
+                $table->foreign('user_id', $this->prefix . 'shipping_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('CASCADE')->onDelete('CASCADE');
             });
 
-            Schema::create('pre_checkout_query', static function (Blueprint $table) {
+            Schema::create($this->prefix . 'pre_checkout_query', function (Blueprint $table) {
                 $table->bigInteger('id')->unsigned()->primary()->comment('Unique query identifier');
                 $table->bigInteger('user_id')->index('user_id')->comment('User who sent the query');
                 $table->char('currency', 3)->comment('Three-letter ISO 4217 currency code');
@@ -29,10 +29,10 @@ class UpdateSchema0560To0570 extends Migration
                 $table->char('shipping_option_id', 255)->comment('Identifier of the shipping option chosen by the user');
                 $table->text('order_info')->comment('Order info provided by the user');
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
-                $table->foreign('user_id', 'pre_checkout_query_ibfk_1')->references('id')->on('user')->onUpdate('CASCADE')->onDelete('CASCADE');
+                $table->foreign('user_id', $this->prefix . 'pre_checkout_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('CASCADE')->onDelete('CASCADE');
             });
 
-            Schema::create('poll', static function (Blueprint $table) {
+            Schema::create($this->prefix . 'poll', static function (Blueprint $table) {
                 $table->bigInteger('id')->unsigned()->primary()->comment('Unique poll identifier');
                 $table->char('question', 255)->comment('Poll question');
                 $table->text('options')->comment('List of poll options');
@@ -40,17 +40,17 @@ class UpdateSchema0560To0570 extends Migration
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
             });
 
-            Schema::table('callback_query', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'callback_query', static function (Blueprint $table) {
                 $table->char('chat_instance', 255)->default('')->comment('Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent')->after('inline_message_id');
                 $table->char('game_short_name', 255)->default('')->comment('Short name of a Game to be returned, serves as the unique identifier for the game')->after('data');
             });
 
-            Schema::table('chat', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'chat', static function (Blueprint $table) {
                 $table->char('first_name', 255)->nullable()->comment('First name of the other party in a private chat')->after('username');
                 $table->char('last_name', 255)->nullable()->comment('Last name of the other party in a private chat')->after('first_name');
             });
 
-            Schema::table('message', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->text('forward_signature')->nullable()->default(null)->comment('For messages forwarded from channels, signature of the post author if present')->after('forward_from_message_id');
                 $table->text('forward_sender_name')->nullable()->default(null)->comment('Sender\'s name for messages forwarded from users who disallow adding a link to their account in forwarded messages')->after('forward_signature');
                 $table->unsignedBigInteger('edit_date')->default(null)->comment('Date the message was last edited in Unix time')->after('reply_to_message');
@@ -61,7 +61,7 @@ class UpdateSchema0560To0570 extends Migration
                 $table->text('successful_payment')->nullable()->comment('Message is a service message about a successful payment, information about the payment')->after('invoice');
             });
 
-            Schema::table('telegram_update', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'telegram_update', function (Blueprint $table) {
                 $table->bigInteger('channel_post_id')->unsigned()->nullable()->comment('New incoming channel post of any kind - text, photo, sticker, etc.');
                 $table->bigInteger('edited_channel_post_id')->unsigned()->nullable()->comment('New version of a channel post that is known to the bot and was edited');
                 $table->bigInteger('shipping_query_id')->unsigned()->nullable()->comment('New incoming shipping query. Only for invoices with flexible price');
@@ -74,11 +74,11 @@ class UpdateSchema0560To0570 extends Migration
                 $table->index('pre_checkout_query_id', 'pre_checkout_query_id');
                 $table->index('poll_id', 'poll_id');
 
-                $table->foreign(['chat_id', 'channel_post_id'], 'telegram_update_ibfk_6')->references(['chat_id', 'id'])->on('message');
-                $table->foreign('edited_channel_post_id', 'telegram_update_ibfk_7')->references('id')->on('edited_message');
-                $table->foreign('shipping_query_id', 'telegram_update_ibfk_8')->references('id')->on('shipping_query');
-                $table->foreign('pre_checkout_query_id', 'telegram_update_ibfk_9')->references('id')->on('pre_checkout_query');
-                $table->foreign('poll_id', 'telegram_update_ibfk_10')->references('id')->on('poll');
+                $table->foreign(['chat_id', 'channel_post_id'], $this->prefix . 'telegram_update_ibfk_6')->references(['chat_id', 'id'])->on($this->prefix . 'message');
+                $table->foreign('edited_channel_post_id', $this->prefix . 'telegram_update_ibfk_7')->references('id')->on($this->prefix . 'edited_message');
+                $table->foreign('shipping_query_id', $this->prefix . 'telegram_update_ibfk_8')->references('id')->on($this->prefix . 'shipping_query');
+                $table->foreign('pre_checkout_query_id', $this->prefix . 'telegram_update_ibfk_9')->references('id')->on($this->prefix . 'pre_checkout_query');
+                $table->foreign('poll_id', $this->prefix . 'telegram_update_ibfk_10')->references('id')->on($this->prefix . 'poll');
             });
         } catch (Exception $e) {
             // Migration may be partly done already...
@@ -88,12 +88,12 @@ class UpdateSchema0560To0570 extends Migration
     public function down(): void
     {
         try {
-            Schema::table('telegram_update', static function (Blueprint $table) {
-                $table->dropForeign('telegram_update_ibfk_10');
-                $table->dropForeign('telegram_update_ibfk_9');
-                $table->dropForeign('telegram_update_ibfk_8');
-                $table->dropForeign('telegram_update_ibfk_7');
-                $table->dropForeign('telegram_update_ibfk_6');
+            Schema::table($this->prefix . 'telegram_update', function (Blueprint $table) {
+                $table->dropForeign($this->prefix . 'telegram_update_ibfk_10');
+                $table->dropForeign($this->prefix . 'telegram_update_ibfk_9');
+                $table->dropForeign($this->prefix . 'telegram_update_ibfk_8');
+                $table->dropForeign($this->prefix . 'telegram_update_ibfk_7');
+                $table->dropForeign($this->prefix . 'telegram_update_ibfk_6');
 
                 $table->dropIndex('poll_id');
                 $table->dropIndex('pre_checkout_query_id');
@@ -108,7 +108,7 @@ class UpdateSchema0560To0570 extends Migration
                 $table->dropColumn('channel_post_id');
             });
 
-            Schema::table('message', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->dropColumn('successful_payment');
                 $table->dropColumn('invoice');
                 $table->dropColumn('poll');
@@ -119,20 +119,19 @@ class UpdateSchema0560To0570 extends Migration
                 $table->dropColumn('forward_signature');
             });
 
-
-            Schema::table('chat', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'chat', static function (Blueprint $table) {
                 $table->dropColumn('last_name');
                 $table->dropColumn('first_name');
             });
 
-            Schema::table('callback_query', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'callback_query', static function (Blueprint $table) {
                 $table->dropColumn('game_short_name');
                 $table->dropColumn('chat_instance');
             });
 
-            Schema::dropIfExists('poll');
-            Schema::dropIfExists('pre_checkout_query');
-            Schema::dropIfExists('shipping_query');
+            Schema::dropIfExists($this->prefix . 'poll');
+            Schema::dropIfExists($this->prefix . 'pre_checkout_query');
+            Schema::dropIfExists($this->prefix . 'shipping_query');
         } catch (Exception $e) {
             // Migration may be partly done already...
         }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use PhpTelegramBot\Laravel\Migration;
 
@@ -17,7 +18,7 @@ class UpdateSchema0560To0570 extends Migration
                 $table->char('invoice_payload', 255)->default('')->comment('Bot specified invoice payload');
                 $table->char('shipping_address', 255)->default('')->comment('User specified shipping address');
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
-                $table->foreign('user_id', $this->prefix . 'shipping_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+                $table->foreign('user_id', 'shipping_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 
             Schema::create($this->prefix . 'pre_checkout_query', function (Blueprint $table) {
@@ -29,7 +30,7 @@ class UpdateSchema0560To0570 extends Migration
                 $table->char('shipping_option_id', 255)->comment('Identifier of the shipping option chosen by the user');
                 $table->text('order_info')->comment('Order info provided by the user');
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
-                $table->foreign('user_id', $this->prefix . 'pre_checkout_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+                $table->foreign('user_id', 'pre_checkout_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 
             Schema::create($this->prefix . 'poll', static function (Blueprint $table) {
@@ -74,14 +75,14 @@ class UpdateSchema0560To0570 extends Migration
                 $table->index('pre_checkout_query_id', 'pre_checkout_query_id');
                 $table->index('poll_id', 'poll_id');
 
-                $table->foreign(['chat_id', 'channel_post_id'], $this->prefix . 'telegram_update_ibfk_6')->references(['chat_id', 'id'])->on($this->prefix . 'message');
-                $table->foreign('edited_channel_post_id', $this->prefix . 'telegram_update_ibfk_7')->references('id')->on($this->prefix . 'edited_message');
-                $table->foreign('shipping_query_id', $this->prefix . 'telegram_update_ibfk_8')->references('id')->on($this->prefix . 'shipping_query');
-                $table->foreign('pre_checkout_query_id', $this->prefix . 'telegram_update_ibfk_9')->references('id')->on($this->prefix . 'pre_checkout_query');
-                $table->foreign('poll_id', $this->prefix . 'telegram_update_ibfk_10')->references('id')->on($this->prefix . 'poll');
+                $table->foreign(['chat_id', 'channel_post_id'], 'telegram_update_ibfk_6')->references(['chat_id', 'id'])->on($this->prefix . 'message');
+                $table->foreign('edited_channel_post_id', 'telegram_update_ibfk_7')->references('id')->on($this->prefix . 'edited_message');
+                $table->foreign('shipping_query_id', 'telegram_update_ibfk_8')->references('id')->on($this->prefix . 'shipping_query');
+                $table->foreign('pre_checkout_query_id', 'telegram_update_ibfk_9')->references('id')->on($this->prefix . 'pre_checkout_query');
+                $table->foreign('poll_id', 'telegram_update_ibfk_10')->references('id')->on($this->prefix . 'poll');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }
@@ -89,12 +90,12 @@ class UpdateSchema0560To0570 extends Migration
     public function down(): void
     {
         try {
-            Schema::table($this->prefix . 'telegram_update', function (Blueprint $table) {
-                $table->dropForeign($this->prefix . 'telegram_update_ibfk_10');
-                $table->dropForeign($this->prefix . 'telegram_update_ibfk_9');
-                $table->dropForeign($this->prefix . 'telegram_update_ibfk_8');
-                $table->dropForeign($this->prefix . 'telegram_update_ibfk_7');
-                $table->dropForeign($this->prefix . 'telegram_update_ibfk_6');
+            Schema::table($this->prefix . 'telegram_update', static function (Blueprint $table) {
+                $table->dropForeign('telegram_update_ibfk_10');
+                $table->dropForeign('telegram_update_ibfk_9');
+                $table->dropForeign('telegram_update_ibfk_8');
+                $table->dropForeign('telegram_update_ibfk_7');
+                $table->dropForeign('telegram_update_ibfk_6');
 
                 $table->dropIndex('poll_id');
                 $table->dropIndex('pre_checkout_query_id');
@@ -134,7 +135,7 @@ class UpdateSchema0560To0570 extends Migration
             Schema::dropIfExists($this->prefix . 'pre_checkout_query');
             Schema::dropIfExists($this->prefix . 'shipping_query');
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
@@ -17,7 +17,7 @@ class UpdateSchema0560To0570 extends Migration
                 $table->char('invoice_payload', 255)->default('')->comment('Bot specified invoice payload');
                 $table->char('shipping_address', 255)->default('')->comment('User specified shipping address');
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
-                $table->foreign('user_id', $this->prefix . 'shipping_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('CASCADE')->onDelete('CASCADE');
+                $table->foreign('user_id', $this->prefix . 'shipping_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 
             Schema::create($this->prefix . 'pre_checkout_query', function (Blueprint $table) {
@@ -29,7 +29,7 @@ class UpdateSchema0560To0570 extends Migration
                 $table->char('shipping_option_id', 255)->comment('Identifier of the shipping option chosen by the user');
                 $table->text('order_info')->comment('Order info provided by the user');
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
-                $table->foreign('user_id', $this->prefix . 'pre_checkout_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('CASCADE')->onDelete('CASCADE');
+                $table->foreign('user_id', $this->prefix . 'pre_checkout_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 
             Schema::create($this->prefix . 'poll', static function (Blueprint $table) {

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
@@ -80,8 +80,8 @@ class UpdateSchema0560To0570 extends Migration
                 $table->foreign('pre_checkout_query_id', $this->prefix . 'telegram_update_ibfk_9')->references('id')->on($this->prefix . 'pre_checkout_query');
                 $table->foreign('poll_id', $this->prefix . 'telegram_update_ibfk_10')->references('id')->on($this->prefix . 'poll');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 
@@ -132,8 +132,8 @@ class UpdateSchema0560To0570 extends Migration
             Schema::dropIfExists($this->prefix . 'poll');
             Schema::dropIfExists($this->prefix . 'pre_checkout_query');
             Schema::dropIfExists($this->prefix . 'shipping_query');
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSchema0560To0570 extends Migration
+{
+    public function up(): void
+    {
+        try {
+            Schema::create('shipping_query', static function (Blueprint $table) {
+                $table->bigInteger('id')->unsigned()->primary()->comment('Unique query identifier');
+                $table->bigInteger('user_id')->index('user_id')->comment('User who sent the query');
+                $table->char('invoice_payload', 255)->default('')->comment('Bot specified invoice payload');
+                $table->char('shipping_address', 255)->default('')->comment('User specified shipping address');
+                $table->dateTime('created_at')->nullable()->comment('Entry date creation');
+                $table->foreign('user_id', 'shipping_query_ibfk_1')->references('id')->on('user')->onUpdate('CASCADE')->onDelete('CASCADE');
+            });
+
+            Schema::create('pre_checkout_query', static function (Blueprint $table) {
+                $table->bigInteger('id')->unsigned()->primary()->comment('Unique query identifier');
+                $table->bigInteger('user_id')->index('user_id')->comment('User who sent the query');
+                $table->char('currency', 3)->comment('Three-letter ISO 4217 currency code');
+                $table->bigInteger('total_amount')->comment('Total price in the smallest units of the currency');
+                $table->char('invoice_payload', 255)->default('')->comment('Bot specified invoice payload');
+                $table->char('shipping_option_id', 255)->comment('Identifier of the shipping option chosen by the user');
+                $table->text('order_info')->comment('Order info provided by the user');
+                $table->dateTime('created_at')->nullable()->comment('Entry date creation');
+                $table->foreign('user_id', 'pre_checkout_query_ibfk_1')->references('id')->on('user')->onUpdate('CASCADE')->onDelete('CASCADE');
+            });
+
+            Schema::create('poll', static function (Blueprint $table) {
+                $table->bigInteger('id')->unsigned()->primary()->comment('Unique poll identifier');
+                $table->char('question', 255)->comment('Poll question');
+                $table->text('options')->comment('List of poll options');
+                $table->tinyInteger('is_closed')->default(0)->comment('True, if the poll is closed');
+                $table->dateTime('created_at')->nullable()->comment('Entry date creation');
+            });
+
+            Schema::table('callback_query', static function (Blueprint $table) {
+                $table->char('chat_instance', 255)->default('')->comment('Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent')->after('inline_message_id');
+                $table->char('game_short_name', 255)->default('')->comment('Short name of a Game to be returned, serves as the unique identifier for the game')->after('data');
+            });
+
+            Schema::table('chat', static function (Blueprint $table) {
+                $table->char('first_name', 255)->nullable()->comment('First name of the other party in a private chat')->after('username');
+                $table->char('last_name', 255)->nullable()->comment('Last name of the other party in a private chat')->after('first_name');
+            });
+
+            Schema::table('message', static function (Blueprint $table) {
+                $table->text('forward_signature')->nullable()->default(null)->comment('For messages forwarded from channels, signature of the post author if present')->after('forward_from_message_id');
+                $table->text('forward_sender_name')->nullable()->default(null)->comment('Sender\'s name for messages forwarded from users who disallow adding a link to their account in forwarded messages')->after('forward_signature');
+                $table->unsignedBigInteger('edit_date')->default(null)->comment('Date the message was last edited in Unix time')->after('reply_to_message');
+                $table->text('author_signature')->comment('Signature of the post author for messages in channels')->after('media_group_id');
+                $table->text('caption_entities')->comment('For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption')->after('entities');
+                $table->text('poll')->comment('Poll object. Message is a native poll, information about the poll')->after('venue');
+                $table->text('invoice')->nullable()->comment('Message is an invoice for a payment, information about the invoice')->after('pinned_message');
+                $table->text('successful_payment')->nullable()->comment('Message is a service message about a successful payment, information about the payment')->after('invoice');
+            });
+
+            Schema::table('telegram_update', static function (Blueprint $table) {
+                $table->bigInteger('channel_post_id')->unsigned()->nullable()->comment('New incoming channel post of any kind - text, photo, sticker, etc.');
+                $table->bigInteger('edited_channel_post_id')->unsigned()->nullable()->comment('New version of a channel post that is known to the bot and was edited');
+                $table->bigInteger('shipping_query_id')->unsigned()->nullable()->comment('New incoming shipping query. Only for invoices with flexible price');
+                $table->bigInteger('pre_checkout_query_id')->unsigned()->nullable()->comment('New incoming pre-checkout query. Contains full information about checkout');
+                $table->bigInteger('poll_id')->unsigned()->nullable()->comment('New poll state. Bots receive only updates about polls, which are sent or stopped by the bot');
+
+                $table->index('channel_post_id', 'channel_post_id');
+                $table->index('edited_channel_post_id', 'edited_channel_post_id');
+                $table->index('shipping_query_id', 'shipping_query_id');
+                $table->index('pre_checkout_query_id', 'pre_checkout_query_id');
+                $table->index('poll_id', 'poll_id');
+
+                $table->foreign(['chat_id', 'channel_post_id'], 'telegram_update_ibfk_6')->references(['chat_id', 'id'])->on('message');
+                $table->foreign('edited_channel_post_id', 'telegram_update_ibfk_7')->references('id')->on('edited_message');
+                $table->foreign('shipping_query_id', 'telegram_update_ibfk_8')->references('id')->on('shipping_query');
+                $table->foreign('pre_checkout_query_id', 'telegram_update_ibfk_9')->references('id')->on('pre_checkout_query');
+                $table->foreign('poll_id', 'telegram_update_ibfk_10')->references('id')->on('poll');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+
+    public function down(): void
+    {
+        try {
+            Schema::table('telegram_update', static function (Blueprint $table) {
+                $table->dropForeign('telegram_update_ibfk_10');
+                $table->dropForeign('telegram_update_ibfk_9');
+                $table->dropForeign('telegram_update_ibfk_8');
+                $table->dropForeign('telegram_update_ibfk_7');
+                $table->dropForeign('telegram_update_ibfk_6');
+
+                $table->dropIndex('poll_id');
+                $table->dropIndex('pre_checkout_query_id');
+                $table->dropIndex('shipping_query_id');
+                $table->dropIndex('edited_channel_post_id');
+                $table->dropIndex('channel_post_id');
+
+                $table->dropColumn('poll_id');
+                $table->dropColumn('pre_checkout_query_id');
+                $table->dropColumn('shipping_query_id');
+                $table->dropColumn('edited_channel_post_id');
+                $table->dropColumn('channel_post_id');
+            });
+
+            Schema::table('message', static function (Blueprint $table) {
+                $table->dropColumn('successful_payment');
+                $table->dropColumn('invoice');
+                $table->dropColumn('poll');
+                $table->dropColumn('caption_entities');
+                $table->dropColumn('author_signature');
+                $table->dropColumn('edit_date');
+                $table->dropColumn('forward_sender_name');
+                $table->dropColumn('forward_signature');
+            });
+
+
+            Schema::table('chat', static function (Blueprint $table) {
+                $table->dropColumn('last_name');
+                $table->dropColumn('first_name');
+            });
+
+            Schema::table('callback_query', static function (Blueprint $table) {
+                $table->dropColumn('game_short_name');
+                $table->dropColumn('chat_instance');
+            });
+
+            Schema::dropIfExists('poll');
+            Schema::dropIfExists('pre_checkout_query');
+            Schema::dropIfExists('shipping_query');
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+}

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
@@ -17,7 +17,7 @@ class UpdateSchema0560To0570 extends Migration
                 $table->bigInteger('user_id')->index('user_id')->comment('User who sent the query');
                 $table->char('invoice_payload', 255)->default('')->comment('Bot specified invoice payload');
                 $table->char('shipping_address', 255)->default('')->comment('User specified shipping address');
-                $table->dateTime('created_at')->nullable()->comment('Entry date creation');
+                $table->timestamp('created_at')->nullable()->comment('Entry date creation');
                 $table->foreign('user_id', 'shipping_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 
@@ -27,9 +27,9 @@ class UpdateSchema0560To0570 extends Migration
                 $table->char('currency', 3)->comment('Three-letter ISO 4217 currency code');
                 $table->bigInteger('total_amount')->comment('Total price in the smallest units of the currency');
                 $table->char('invoice_payload', 255)->default('')->comment('Bot specified invoice payload');
-                $table->char('shipping_option_id', 255)->comment('Identifier of the shipping option chosen by the user');
-                $table->text('order_info')->comment('Order info provided by the user');
-                $table->dateTime('created_at')->nullable()->comment('Entry date creation');
+                $table->char('shipping_option_id', 255)->nullable()->comment('Identifier of the shipping option chosen by the user');
+                $table->text('order_info')->nullable()->comment('Order info provided by the user');
+                $table->timestamp('created_at')->nullable()->comment('Entry date creation');
                 $table->foreign('user_id', 'pre_checkout_query_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 
@@ -37,8 +37,8 @@ class UpdateSchema0560To0570 extends Migration
                 $table->bigInteger('id')->unsigned()->primary()->comment('Unique poll identifier');
                 $table->char('question', 255)->comment('Poll question');
                 $table->text('options')->comment('List of poll options');
-                $table->tinyInteger('is_closed')->default(0)->comment('True, if the poll is closed');
-                $table->dateTime('created_at')->nullable()->comment('Entry date creation');
+                $table->boolean('is_closed')->default(0)->comment('True, if the poll is closed');
+                $table->timestamp('created_at')->nullable()->comment('Entry date creation');
             });
 
             Schema::table($this->prefix . 'callback_query', static function (Blueprint $table) {
@@ -54,10 +54,10 @@ class UpdateSchema0560To0570 extends Migration
             Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->text('forward_signature')->nullable()->default(null)->comment('For messages forwarded from channels, signature of the post author if present')->after('forward_from_message_id');
                 $table->text('forward_sender_name')->nullable()->default(null)->comment('Sender\'s name for messages forwarded from users who disallow adding a link to their account in forwarded messages')->after('forward_signature');
-                $table->unsignedBigInteger('edit_date')->default(null)->comment('Date the message was last edited in Unix time')->after('reply_to_message');
-                $table->text('author_signature')->comment('Signature of the post author for messages in channels')->after('media_group_id');
-                $table->text('caption_entities')->comment('For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption')->after('entities');
-                $table->text('poll')->comment('Poll object. Message is a native poll, information about the poll')->after('venue');
+                $table->unsignedBigInteger('edit_date')->nullable()->comment('Date the message was last edited in Unix time')->after('reply_to_message');
+                $table->text('author_signature')->nullable()->comment('Signature of the post author for messages in channels')->after('media_group_id');
+                $table->text('caption_entities')->nullable()->comment('For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption')->after('entities');
+                $table->text('poll')->nullable()->comment('Poll object. Message is a native poll, information about the poll')->after('venue');
                 $table->text('invoice')->nullable()->comment('Message is an invoice for a payment, information about the invoice')->after('pinned_message');
                 $table->text('successful_payment')->nullable()->comment('Message is a service message about a successful payment, information about the payment')->after('invoice');
             });

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_56_0_to_0_57_0.php
@@ -81,6 +81,7 @@ class UpdateSchema0560To0570 extends Migration
                 $table->foreign('poll_id', $this->prefix . 'telegram_update_ibfk_10')->references('id')->on($this->prefix . 'poll');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }
@@ -133,6 +134,7 @@ class UpdateSchema0560To0570 extends Migration
             Schema::dropIfExists($this->prefix . 'pre_checkout_query');
             Schema::dropIfExists($this->prefix . 'shipping_query');
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
@@ -16,6 +16,7 @@ class UpdateSchema0570To0580 extends Migration
                 $table->text('reply_markup')->nullable()->comment('Inline keyboard attached to the message')->after('passport_data');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }
@@ -27,6 +28,7 @@ class UpdateSchema0570To0580 extends Migration
                 $table->dropColumn('reply_markup');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
@@ -15,8 +15,8 @@ class UpdateSchema0570To0580 extends Migration
             Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->text('reply_markup')->nullable()->comment('Inline keyboard attached to the message')->after('passport_data');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 
@@ -26,8 +26,8 @@ class UpdateSchema0570To0580 extends Migration
             Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->dropColumn('reply_markup');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
@@ -25,6 +25,15 @@ class UpdateSchema0570To0580 extends Migration
     public function down(): void
     {
         try {
+            Schema::create('botan_shortener', function (Blueprint $table) {
+                $table->bigInteger('id', true)->unsigned()->comment('Unique identifier for this entry');
+                $table->bigInteger('user_id')->nullable()->index('user_id')->comment('Unique user identifier');
+                $table->text('url')->comment('Original URL');
+                $table->char('short_url')->default('')->comment('Shortened URL');
+                $table->timestamp('created_at')->nullable()->comment('Entry date creation');
+                $table->foreign('user_id', 'botan_shortener_ibfk_1')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+
             Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->dropColumn('reply_markup');
             });

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use PhpTelegramBot\Laravel\Migration;
 
@@ -16,7 +17,7 @@ class UpdateSchema0570To0580 extends Migration
                 $table->text('reply_markup')->nullable()->comment('Inline keyboard attached to the message')->after('passport_data');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }
@@ -28,7 +29,7 @@ class UpdateSchema0570To0580 extends Migration
                 $table->dropColumn('reply_markup');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
 
 class UpdateSchema0570To0580 extends Migration
 {
     public function up(): void
     {
         try {
-            Schema::table('message', static function (Blueprint $table) {
+            Schema::dropIfExists($this->prefix . 'botan_shortener');
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->text('reply_markup')->nullable()->comment('Inline keyboard attached to the message')->after('passport_data');
             });
         } catch (Exception $e) {
@@ -22,7 +23,7 @@ class UpdateSchema0570To0580 extends Migration
     public function down(): void
     {
         try {
-            Schema::table('message', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
                 $table->dropColumn('reply_markup');
             });
         } catch (Exception $e) {

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_57_0_to_0_58_0.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSchema0570To0580 extends Migration
+{
+    public function up(): void
+    {
+        try {
+            Schema::table('message', static function (Blueprint $table) {
+                $table->text('reply_markup')->nullable()->comment('Inline keyboard attached to the message')->after('passport_data');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+
+    public function down(): void
+    {
+        try {
+            Schema::table('message', static function (Blueprint $table) {
+                $table->dropColumn('reply_markup');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+}

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
@@ -18,8 +18,8 @@ class UpdateSchema0600To0610 extends Migration
                 $table->index('message_id', 'message_id');
                 $table->index(['chat_id', 'message_id'], 'chat_message_id');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
 
         Schema::enableForeignKeyConstraints();
@@ -35,8 +35,8 @@ class UpdateSchema0600To0610 extends Migration
                 $table->dropIndex('message_id');
                 $table->index('message_id', 'message_id');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
 
         Schema::enableForeignKeyConstraints();

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
@@ -19,6 +19,7 @@ class UpdateSchema0600To0610 extends Migration
                 $table->index(['chat_id', 'message_id'], 'chat_message_id');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
 
@@ -36,6 +37,7 @@ class UpdateSchema0600To0610 extends Migration
                 $table->index('message_id', 'message_id');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
 

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSchema0600To0610 extends Migration
+{
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        try {
+            Schema::table('telegram_update', static function (Blueprint $table) {
+                $table->dropIndex('message_id');
+                $table->index('message_id', 'message_id');
+                $table->index(['chat_id', 'message_id'], 'chat_message_id');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    public function down(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        try {
+            Schema::table('telegram_update', static function (Blueprint $table) {
+                $table->dropIndex('chat_message_id');
+                $table->dropIndex('message_id');
+                $table->index('message_id', 'message_id');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+
+        Schema::enableForeignKeyConstraints();
+    }
+}

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use PhpTelegramBot\Laravel\Migration;
 
@@ -19,7 +20,7 @@ class UpdateSchema0600To0610 extends Migration
                 $table->index(['chat_id', 'message_id'], 'chat_message_id');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
 
@@ -37,7 +38,7 @@ class UpdateSchema0600To0610 extends Migration
                 $table->index('message_id', 'message_id');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
 

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_60_0_to_0_61_0.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
 
 class UpdateSchema0600To0610 extends Migration
 {
@@ -13,7 +13,7 @@ class UpdateSchema0600To0610 extends Migration
         Schema::disableForeignKeyConstraints();
 
         try {
-            Schema::table('telegram_update', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'telegram_update', static function (Blueprint $table) {
                 $table->dropIndex('message_id');
                 $table->index('message_id', 'message_id');
                 $table->index(['chat_id', 'message_id'], 'chat_message_id');
@@ -30,7 +30,7 @@ class UpdateSchema0600To0610 extends Migration
         Schema::disableForeignKeyConstraints();
 
         try {
-            Schema::table('telegram_update', static function (Blueprint $table) {
+            Schema::table($this->prefix . 'telegram_update', static function (Blueprint $table) {
                 $table->dropIndex('chat_message_id');
                 $table->dropIndex('message_id');
                 $table->index('message_id', 'message_id');

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
@@ -13,11 +13,11 @@ class UpdateSchema0611To0620 extends Migration
     {
         try {
             Schema::table($this->prefix . 'poll', static function (Blueprint $table) {
-                $table->integer('total_voter_count')->unsigned()->comment('Total number of users that voted in the poll')->after('options');
-                $table->tinyInteger('is_anonymous')->default(1)->comment('True, if the poll is anonymous')->after('is_closed');
+                $table->integer('total_voter_count')->unsigned()->nullable()->comment('Total number of users that voted in the poll')->after('options');
+                $table->boolean('is_anonymous')->default(1)->comment('True, if the poll is anonymous')->after('is_closed');
                 $table->char('type', 255)->comment('Poll type, currently can be "regular" or "quiz"')->after('is_anonymous');
-                $table->tinyInteger('allows_multiple_answers')->default(0)->comment('True, if the poll allows multiple answers')->after('type');
-                $table->integer('correct_option_id')->unsigned()->comment('0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot.')->after('allows_multiple_answers');
+                $table->boolean('allows_multiple_answers')->default(0)->comment('True, if the poll allows multiple answers')->after('type');
+                $table->integer('correct_option_id')->unsigned()->nullable()->comment('0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot.')->after('allows_multiple_answers');
             });
 
             Schema::table($this->prefix . 'message', static function (Blueprint $table) {
@@ -25,10 +25,11 @@ class UpdateSchema0611To0620 extends Migration
             });
 
             Schema::create($this->prefix . 'poll_answer', function (Blueprint $table) {
-                $table->bigInteger('poll_id', true, true)->comment('Unique poll identifier');
-                $table->bigInteger('user_id')->nullable(false)->comment('The user, who changed the answer to the poll');
-                $table->text('option_ids')->nullable(false)->comment('0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.');
-                $table->dateTime('created_at')->nullable()->comment('Entry date creation');
+                $table->bigInteger('poll_id')->unsigned()->comment('Unique poll identifier');
+                $table->bigInteger('user_id')->comment('The user, who changed the answer to the poll');
+                $table->text('option_ids')->comment('0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.');
+                $table->timestamp('created_at')->nullable()->comment('Entry date creation');
+                $table->primary(['poll_id', 'user_id']);
                 $table->foreign('poll_id', 'poll_answer_ibfk_1')->references('id')->on($this->prefix . 'poll')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSchema0611To0620 extends Migration
+{
+    public function up(): void
+    {
+        try {
+            Schema::table('poll', static function (Blueprint $table) {
+                $table->integer('total_voter_count')->unsigned()->comment('Total number of users that voted in the poll')->after('options');
+                $table->tinyInteger('is_anonymous')->default(1)->comment('True, if the poll is anonymous')->after('is_closed');
+                $table->char('type', 255)->comment('Poll type, currently can be “regular” or “quiz”')->after('is_anonymous');
+                $table->tinyInteger('allows_multiple_answers')->default(0)->comment('True, if the poll allows multiple answers')->after('type');
+                $table->integer('correct_option_id')->unsigned()->comment('0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot.')->after('allows_multiple_answers');
+            });
+
+            Schema::table('message', static function (Blueprint $table) {
+                $table->text('dice')->nullable()->comment('Message is a dice with random value from 1 to 6')->after('poll');
+            });
+
+            Schema::create('poll_answer', static function (Blueprint $table) {
+                $table->bigInteger('poll_id', true, true)->comment('Unique poll identifier');
+                $table->bigInteger('user_id')->nullable(false)->comment('The user, who changed the answer to the poll');
+                $table->text('option_ids')->nullable(false)->comment('0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.');
+                $table->dateTime('created_at')->nullable()->comment('Entry date creation');
+                $table->foreign('poll_id', 'poll_answer_ibfk_1')->references('id')->on('poll')->onUpdate('CASCADE')->onDelete('CASCADE');
+            });
+
+            Schema::table('telegram_update', static function (Blueprint $table) {
+                $table->bigInteger('poll_answer_poll_id')->unsigned()->nullable()->comment('A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.')->after('poll_id');
+                $table->index('poll_answer_poll_id', 'poll_answer_poll_id');
+                $table->foreign('poll_answer_poll_id', 'telegram_update_ibfk_11')->references('poll_id')->on('poll_answer')->onUpdate('CASCADE')->onDelete('CASCADE');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+
+    public function down(): void
+    {
+        try {
+            Schema::table('telegram_update', static function (Blueprint $table) {
+                $table->dropForeign('telegram_update_ibfk_11');
+                $table->dropIndex('poll_answer_poll_id');
+                $table->dropColumn('poll_answer_poll_id');
+            });
+
+            Schema::dropIfExists('poll_answer');
+
+            Schema::table('message', static function (Blueprint $table) {
+                $table->dropColumn('dice');
+            });
+
+            Schema::table('poll', static function (Blueprint $table) {
+                $table->dropColumn('correct_option_id');
+                $table->dropColumn('allows_multiple_answers');
+                $table->dropColumn('type');
+                $table->dropColumn('is_anonymous');
+                $table->dropColumn('total_voter_count');
+            });
+        } catch (Exception $e) {
+            // Migration may be partly done already...
+        }
+    }
+}

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use PhpTelegramBot\Laravel\Migration;
 
@@ -28,16 +29,16 @@ class UpdateSchema0611To0620 extends Migration
                 $table->bigInteger('user_id')->nullable(false)->comment('The user, who changed the answer to the poll');
                 $table->text('option_ids')->nullable(false)->comment('0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.');
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
-                $table->foreign('poll_id', $this->prefix . 'poll_answer_ibfk_1')->references('id')->on($this->prefix . 'poll')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+                $table->foreign('poll_id', 'poll_answer_ibfk_1')->references('id')->on($this->prefix . 'poll')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 
             Schema::table($this->prefix . 'telegram_update', function (Blueprint $table) {
                 $table->bigInteger('poll_answer_poll_id')->unsigned()->nullable()->comment('A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.')->after('poll_id');
                 $table->index('poll_answer_poll_id', 'poll_answer_poll_id');
-                $table->foreign('poll_answer_poll_id', $this->prefix . 'telegram_update_ibfk_11')->references('poll_id')->on($this->prefix . 'poll_answer')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+                $table->foreign('poll_answer_poll_id', 'telegram_update_ibfk_11')->references('poll_id')->on($this->prefix . 'poll_answer')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }
@@ -45,8 +46,8 @@ class UpdateSchema0611To0620 extends Migration
     public function down(): void
     {
         try {
-            Schema::table($this->prefix . 'telegram_update', function (Blueprint $table) {
-                $table->dropForeign($this->prefix . 'telegram_update_ibfk_11');
+            Schema::table($this->prefix . 'telegram_update', static function (Blueprint $table) {
+                $table->dropForeign('telegram_update_ibfk_11');
                 $table->dropIndex('poll_answer_poll_id');
                 $table->dropColumn('poll_answer_poll_id');
             });
@@ -65,7 +66,7 @@ class UpdateSchema0611To0620 extends Migration
                 $table->dropColumn('total_voter_count');
             });
         } catch (Throwable $e) {
-            \Log::error($e->getMessage ());
+            Log::error($e->getMessage());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
@@ -37,6 +37,7 @@ class UpdateSchema0611To0620 extends Migration
                 $table->foreign('poll_answer_poll_id', $this->prefix . 'telegram_update_ibfk_11')->references('poll_id')->on($this->prefix . 'poll_answer')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }
@@ -64,6 +65,7 @@ class UpdateSchema0611To0620 extends Migration
                 $table->dropColumn('total_voter_count');
             });
         } catch (Throwable $e) {
+            \Log::error($e->getMessage ());
             return; // Migration may be partly done already...
         }
     }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
@@ -36,8 +36,8 @@ class UpdateSchema0611To0620 extends Migration
                 $table->index('poll_answer_poll_id', 'poll_answer_poll_id');
                 $table->foreign('poll_answer_poll_id', $this->prefix . 'telegram_update_ibfk_11')->references('poll_id')->on($this->prefix . 'poll_answer')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 
@@ -63,8 +63,8 @@ class UpdateSchema0611To0620 extends Migration
                 $table->dropColumn('is_anonymous');
                 $table->dropColumn('total_voter_count');
             });
-        } catch (Exception $e) {
-            // Migration may be partly done already...
+        } catch (Throwable $e) {
+            return; // Migration may be partly done already...
         }
     }
 }

--- a/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_0_61_1_to_0_62_0.php
@@ -14,7 +14,7 @@ class UpdateSchema0611To0620 extends Migration
             Schema::table($this->prefix . 'poll', static function (Blueprint $table) {
                 $table->integer('total_voter_count')->unsigned()->comment('Total number of users that voted in the poll')->after('options');
                 $table->tinyInteger('is_anonymous')->default(1)->comment('True, if the poll is anonymous')->after('is_closed');
-                $table->char('type', 255)->comment('Poll type, currently can be “regular” or “quiz”')->after('is_anonymous');
+                $table->char('type', 255)->comment('Poll type, currently can be "regular" or "quiz"')->after('is_anonymous');
                 $table->tinyInteger('allows_multiple_answers')->default(0)->comment('True, if the poll allows multiple answers')->after('type');
                 $table->integer('correct_option_id')->unsigned()->comment('0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot.')->after('allows_multiple_answers');
             });
@@ -28,13 +28,13 @@ class UpdateSchema0611To0620 extends Migration
                 $table->bigInteger('user_id')->nullable(false)->comment('The user, who changed the answer to the poll');
                 $table->text('option_ids')->nullable(false)->comment('0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.');
                 $table->dateTime('created_at')->nullable()->comment('Entry date creation');
-                $table->foreign('poll_id', $this->prefix . 'poll_answer_ibfk_1')->references('id')->on($this->prefix . 'poll')->onUpdate('CASCADE')->onDelete('CASCADE');
+                $table->foreign('poll_id', $this->prefix . 'poll_answer_ibfk_1')->references('id')->on($this->prefix . 'poll')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
 
             Schema::table($this->prefix . 'telegram_update', function (Blueprint $table) {
                 $table->bigInteger('poll_answer_poll_id')->unsigned()->nullable()->comment('A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.')->after('poll_id');
                 $table->index('poll_answer_poll_id', 'poll_answer_poll_id');
-                $table->foreign('poll_answer_poll_id', $this->prefix . 'telegram_update_ibfk_11')->references('poll_id')->on($this->prefix . 'poll_answer')->onUpdate('CASCADE')->onDelete('CASCADE');
+                $table->foreign('poll_answer_poll_id', $this->prefix . 'telegram_update_ibfk_11')->references('poll_id')->on($this->prefix . 'poll_answer')->onUpdate('RESTRICT')->onDelete('RESTRICT');
             });
         } catch (Exception $e) {
             // Migration may be partly done already...

--- a/src/database/migrations/2020_05_18_000000_update_schema_fixes.php
+++ b/src/database/migrations/2020_05_18_000000_update_schema_fixes.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
+
+class UpdateSchemaFixes extends Migration
+{
+    public function up(): void
+    {
+        try {
+            Schema::table($this->prefix . 'callback_query', function (Blueprint $table) {
+                $table->dropForeign('callback_query_ibfk_2');
+                $table->foreign(['chat_id', 'message_id'], 'callback_query_ibfk_2')->references(['chat_id', 'id'])->on($this->prefix . 'message')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+
+            Schema::table($this->prefix . 'edited_message', function (Blueprint $table) {
+                $table->dropForeign('edited_message_ibfk_2');
+                $table->foreign(['chat_id', 'message_id'], 'edited_message_ibfk_2')->references(['chat_id', 'id'])->on($this->prefix . 'message')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+
+            Schema::table($this->prefix . 'message', function (Blueprint $table) {
+                $table->dropForeign('message_ibfk_5');
+                $table->dropForeign('message_ibfk_6');
+                $table->foreign(['reply_to_chat', 'reply_to_message'], 'message_ibfk_5')->references(['chat_id', 'id'])->on($this->prefix . 'message')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+        } catch (Throwable $e) {
+            Log::error($e->getMessage());
+            return; // Migration may be partly done already...
+        }
+    }
+
+    public function down(): void
+    {
+        try {
+            Schema::table($this->prefix . 'callback_query', function (Blueprint $table) {
+                $table->dropForeign('callback_query_ibfk_2');
+                $table->foreign('chat_id', 'callback_query_ibfk_2')->references('chat_id')->on($this->prefix . 'message')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+
+            Schema::table($this->prefix . 'edited_message', function (Blueprint $table) {
+                $table->dropForeign('edited_message_ibfk_2');
+                $table->foreign('chat_id', 'edited_message_ibfk_2')->references('chat_id')->on($this->prefix . 'message')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+
+            Schema::table($this->prefix . 'message', function (Blueprint $table) {
+                $table->dropForeign('message_ibfk_5');
+                $table->foreign('reply_to_chat', 'message_ibfk_5')->references('chat_id')->on($this->prefix . 'message')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+                $table->foreign('forward_from', 'message_ibfk_6')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+        } catch (Throwable $e) {
+            Log::error($e->getMessage());
+            return; // Migration may be partly done already...
+        }
+    }
+}

--- a/src/database/migrations/2020_05_18_010919_convert_datetime_to_timetamp.php
+++ b/src/database/migrations/2020_05_18_010919_convert_datetime_to_timetamp.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpTelegramBot\Laravel\Migration;
+
+class ConvertDatetimeToTimetamp extends Migration
+{
+    /** @var array[] Fields that require DATETIME to TIMESTAMP conversion. */
+    private $table_columns = [
+        'callback_query'       => ['created_at'],
+        'chosen_inline_result' => ['created_at'],
+        'edited_message'       => ['edit_date'],
+        'inline_query'         => ['created_at'],
+        'message'              => ['date', 'forward_date'],
+        'request_limiter'      => ['created_at'],
+    ];
+
+    public function up(): void
+    {
+        $this->changeColumnTypes($this->table_columns, 'TIMESTAMP NULL DEFAULT NULL');
+    }
+
+    public function down(): void
+    {
+        $this->changeColumnTypes($this->table_columns, 'DATETIME NULL DEFAULT NULL');
+    }
+}

--- a/src/database/migrations/2021_01_04_000000_update_schema_0_62_0_to_0_63_0.php
+++ b/src/database/migrations/2021_01_04_000000_update_schema_0_62_0_to_0_63_0.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
+
+class UpdateSchema0620To0630 extends Migration
+{
+    public function up(): void
+    {
+        try {
+            Schema::table($this->prefix . 'poll', static function (Blueprint $table) {
+                $table->char('explanation', 255)->nullable()->comment('Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters')->after('correct_option_id');
+                $table->text('explanation_entities')->nullable()->comment('Special entities like usernames, URLs, bot commands, etc. that appear in the explanation')->after('explanation');
+                $table->integer('open_period')->unsigned()->nullable()->comment('Amount of time in seconds the poll will be active after creation')->after('explanation_entities');
+                $table->timestamp('close_date')->nullable()->comment('Point in time (Unix timestamp) when the poll will be automatically closed')->after('open_period');
+            });
+
+            Schema::table($this->prefix . 'poll_answer', static function (Blueprint $table) {
+                $table->dropPrimary();
+                $table->primary(['poll_id', 'user_id']);
+            });
+
+            Schema::table($this->prefix . 'message', function (Blueprint $table) {
+                $table->dropForeign('message_ibfk_6');
+                $table->dropIndex('message_ibfk_6');
+
+                $table->bigInteger('via_bot')->nullable()->comment('Optional. Bot through which the message was sent')->after('reply_to_message');
+                $table->index('via_bot');
+                $table->foreign('via_bot', 'message_ibfk_9')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+        } catch (Throwable $e) {
+            Log::error($e->getMessage());
+            return; // Migration may be partly done already...
+        }
+    }
+
+    public function down(): void
+    {
+        try {
+            Schema::table($this->prefix . 'poll', static function (Blueprint $table) {
+                $table->dropColumn('explanation');
+                $table->dropColumn('explanation_entities');
+                $table->dropColumn('open_period');
+                $table->dropColumn('close_date');
+            });
+
+            Schema::table($this->prefix . 'poll_answer', static function (Blueprint $table) {
+                $table->dropPrimary();
+                $table->primary('poll_id');
+            });
+
+            Schema::table($this->prefix . 'message', function (Blueprint $table) {
+                $table->dropForeign('message_ibfk_9');
+                $table->dropIndex('via_bot');
+                $table->dropColumn('via_bot');
+
+                $table->foreign('forward_from', 'message_ibfk_6')->references('id')->on($this->prefix . 'user')->onUpdate('RESTRICT')->onDelete('RESTRICT');
+            });
+        } catch (Throwable $e) {
+            Log::error($e->getMessage());
+            return; // Migration may be partly done already...
+        }
+    }
+}

--- a/src/database/migrations/2021_01_04_000000_update_schema_0_64_0_to_0_70_0.php
+++ b/src/database/migrations/2021_01_04_000000_update_schema_0_64_0_to_0_70_0.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use PhpTelegramBot\Laravel\Migration;
+
+class UpdateSchema0640To0700 extends Migration
+{
+    public function up(): void
+    {
+        try {
+            $this->changeColumnTypes(['poll' => ['question']], 'text');
+
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
+                $table->bigInteger('sender_chat_id')->comment('Sender of the message, sent on behalf of a chat')->after('chat_id');
+                $table->text('proximity_alert_triggered')->nullable()->comment('Service message. A user in the chat triggered another user\'s proximity alert while sharing Live Location.')->after('passport_data');
+            });
+        } catch (Throwable $e) {
+            Log::error($e->getMessage());
+            return; // Migration may be partly done already...
+        }
+    }
+
+    public function down(): void
+    {
+        try {
+            Schema::table($this->prefix . 'message', static function (Blueprint $table) {
+                $table->dropColumn('proximity_alert_triggered');
+                $table->dropColumn('sender_chat_id');
+            });
+
+            $this->changeColumnTypes(['poll' => ['question']], 'char(255)');
+        } catch (Throwable $e) {
+            Log::error($e->getMessage());
+            return; // Migration may be partly done already...
+        }
+    }
+}


### PR DESCRIPTION
This still needs to take the prefix into account.

Do we overwrite the entire Laravel prefix here or does the prefix need to be added to the Laravel one?

I've added the `try-catch` blocks to make sure that migrations will also go through for tables that have been manually updated.
Not sure how best to ensure that the table is in a 100% correct state.
Maybe check each call specifically with an `if` conditional?

Fixes #13 
Fixes #20

@asafov @akalongman 