### PR TITLE
Added create directories before creating file

### DIFF
--- a/src/Console/Commands/GeneratorCommand.php
+++ b/src/Console/Commands/GeneratorCommand.php
@@ -17,6 +17,12 @@ abstract class GeneratorCommand extends Command
             return false;
         }
 
+        $path_parts = pathinfo($destination);
+        if (!mkdir($path_parts['dirname'], 0755, true)) {
+            $this->error("{$$path_parts['dirname']} failed to create!");
+            return false;
+        }
+
         $content = file_get_contents($source);
         $content = $this->replacePlaceholder($content, $replacements);
         file_put_contents($destination, $content);

--- a/src/Console/Commands/GeneratorCommand.php
+++ b/src/Console/Commands/GeneratorCommand.php
@@ -19,7 +19,7 @@ abstract class GeneratorCommand extends Command
 
         $path_parts = pathinfo($destination);
         if (!mkdir($path_parts['dirname'], 0755, true)) {
-            $this->error("{$$path_parts['dirname']} failed to create!");
+            $this->error("{$destination} failed to create!");
             return false;
         }
 


### PR DESCRIPTION
Bug fix if no directories are created

> php artisan make:telegram-command Menu
> 
>    ErrorException 
> 
>   file_put_contents(/var/www/html/app/Telegram/Commands/MenuCommand.php): Failed to open stream: No such file or directory
> 
>   at vendor/php-telegram-bot/laravel/src/Console/Commands/GeneratorCommand.php:28
>      24▕         // }
>      25▕ 
>      26▕         $content = file_get_contents($source);
>      27▕         $content = $this->replacePlaceholder($content, $replacements);
>   ➜  28▕         file_put_contents($destination, $content);
>      29▕ 
>      30▕         return true;
>      31▕     }
>      32▕ 