### PR TITLE
Drop Database Tables on Migration Rollback

### DIFF
--- a/database/migrations/2021_06_14_171118_create_telegram_bot_structure.php
+++ b/database/migrations/2021_06_14_171118_create_telegram_bot_structure.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
     public function up()
@@ -10,6 +12,25 @@ return new class extends Migration {
 
     public function down()
     {
-        //
+        Schema::disableForeignKeyConstraints();
+
+        Schema::dropIfExists('bot_user');
+        Schema::dropIfExists('bot_chat');
+        Schema::dropIfExists('bot_user_chat');
+        Schema::dropIfExists('bot_inline_query');
+        Schema::dropIfExists('bot_chosen_inline_result');
+        Schema::dropIfExists('bot_message');
+        Schema::dropIfExists('bot_edited_message');
+        Schema::dropIfExists('bot_callback_query');
+        Schema::dropIfExists('bot_shipping_query');
+        Schema::dropIfExists('bot_pre_checkout_query');
+        Schema::dropIfExists('bot_poll');
+        Schema::dropIfExists('bot_poll_answer');
+        Schema::dropIfExists('bot_chat_member_updated');
+        Schema::dropIfExists('bot_telegram_update');
+        Schema::dropIfExists('bot_conversation');
+        Schema::dropIfExists('bot_request_limiter');
+
+        Schema::enableForeignKeyConstraints();
     }
 };

--- a/database/migrations/2022_02_18_175100_update_to_0.75.0.php
+++ b/database/migrations/2022_02_18_175100_update_to_0.75.0.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
     public function up()
@@ -10,6 +12,8 @@ return new class extends Migration {
 
     public function down()
     {
-        //
+        Schema::disableForeignKeyConstraints();
+        Schema::dropIfExists('bot_chat_join_request');
+        Schema::enableForeignKeyConstraints();
     }
 };

--- a/database/migrations/2022_04_24_175700_update_to_0.77.0.php
+++ b/database/migrations/2022_04_24_175700_update_to_0.77.0.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up()

--- a/database/migrations/2022_10_04_221900_update_to_0.78.0.php
+++ b/database/migrations/2022_10_04_221900_update_to_0.78.0.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up()


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR fixes errors encountered when running `artisan migrate:refresh` due to tables not being dropped.

- Drop database tables upon migration rollback.